### PR TITLE
Simplify AsyncRead dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ v4 = []
 appveyor = []
 
 [dependencies]
-async-std = "1"
 byteorder = "1"
+futures = "0.3"
 log = "0.4.1"
 rand = "0.4.1"
 snap = "0.2.3"

--- a/src/frame/parser_async.rs
+++ b/src/frame/parser_async.rs
@@ -2,8 +2,7 @@ use std::cell::RefCell;
 use std::io::{Cursor, Read};
 use std::marker::Unpin;
 
-use async_std::io::Read as AsyncRead;
-use async_std::prelude::*;
+use futures::io::{AsyncRead, AsyncReadExt};
 
 use super::*;
 use crate::compression::Compressor;


### PR DESCRIPTION
`async-std` merely re-exports `futures::io` traits, so no need to bloat the dependency graph here.