### PR TITLE
zero-initialize buffer before passing to `Read`

### DIFF
--- a/src/frame/parser.rs
+++ b/src/frame/parser.rs
@@ -36,11 +36,10 @@ where
     let opcode = Opcode::from(opcode_bytes[0]);
     let length = from_bytes(&length_bytes) as usize;
 
-    let mut body_bytes = Vec::with_capacity(length);
-    unsafe {
-        body_bytes.set_len(length);
-    }
-
+    // FIXME:
+    //   Once a new feature to safely pass an uninitialized buffer to `Read` becomes available,
+    //   we no longer need to zero-initialize `body_bytes` before passing to `Read`.
+    let mut body_bytes = vec![0; length];
     cursor.read_exact(&mut body_bytes)?;
 
     let full_body = if flags.iter().any(|flag| flag == &Flag::Compression) {

--- a/src/frame/parser_async.rs
+++ b/src/frame/parser_async.rs
@@ -43,10 +43,10 @@ where
   let opcode = Opcode::from(opcode_bytes[0]);
   let length = from_bytes(&length_bytes) as usize;
 
-  let mut body_bytes = Vec::with_capacity(length);
-  unsafe {
-    body_bytes.set_len(length);
-  }
+  // FIXME:
+    //   Once a new feature to safely pass an uninitialized buffer to `Read` becomes available,
+    //   we no longer need to zero-initialize `body_bytes` before passing to `Read`.
+  let mut body_bytes = vec![0; length];
 
   proceed_if_filled!(cursor.read(&mut body_bytes), length);
 
@@ -62,10 +62,10 @@ where
   let mut body_cursor = Cursor::new(full_body.as_slice());
 
   let tracing_id = if flags.iter().any(|flag| flag == &Flag::Tracing) {
-    let mut tracing_bytes = Vec::with_capacity(UUID_LEN);
-    unsafe {
-      tracing_bytes.set_len(UUID_LEN);
-    }
+    // FIXME:
+    //   Once a new feature to safely pass an uninitialized buffer to `Read` becomes available,
+    //   we no longer need to zero-initialize `tracing_bytes` before passing to `Read`.
+    let mut tracing_bytes = vec![0; UUID_LEN];
     body_cursor.read_exact(&mut tracing_bytes)?;
 
     decode_timeuuid(tracing_bytes.as_slice()).ok()


### PR DESCRIPTION
Closes #3

The Naive & safe way to fix the issue is to always zero-initialize a buffer before lending it to a user-provided `Read` implementation. Note that this approach will add runtime performance overhead of zero-initializing the buffer.

This PR applies zero-initialization for fixing the issue.
I also added a `FIXME` comment to indicate that a better fix may be available in the future.

As of Feb 2021, there is not yet an ideal fix that works in stable Rust with no performance overhead.
Below are links to relevant discussions & suggestions for the fix.

* [Well-written document regarding the issue](https://paper.dropbox.com/doc/IO-Buffer-Initialization-MvytTgjIOTNpJAS6Mvw38)
* [Rust RFC 2930](https://github.com/rust-lang/rfcs/blob/master/text/2930-read-buf.md#summary)
* [nightly feature `std::io::Initializer`](https://doc.rust-lang.org/std/io/struct.Initializer.html)
* [Discussion in Rust Internals Forum](https://internals.rust-lang.org/t/uninitialized-memory/1652)

Thank you for reviewing this PR :+1: 