### PR TITLE
Fix tests and some warnings

### DIFF
--- a/src/frame/events.rs
+++ b/src/frame/events.rs
@@ -486,7 +486,7 @@ mod server_event {
         match event {
             ServerEvent::TopologyChange(ref tc) => {
                 assert_eq!(tc.change_type, TopologyChangeType::NewNode);
-                assert_eq!(format!("{:?}", tc.addr.addr), "V4(127.0.0.1:1)");
+                assert_eq!(tc.addr.addr, "127.0.0.1:1".parse().unwrap());
             }
             _ => panic!("should be topology change event"),
         }
@@ -543,7 +543,7 @@ mod server_event {
         match event {
             ServerEvent::TopologyChange(ref tc) => {
                 assert_eq!(tc.change_type, TopologyChangeType::RemovedNode);
-                assert_eq!(format!("{:?}", tc.addr.addr), "V4(127.0.0.1:1)");
+                assert_eq!(tc.addr.addr, "127.0.0.1:1".parse().unwrap());
             }
             _ => panic!("should be topology change event"),
         }
@@ -588,7 +588,7 @@ mod server_event {
         match event {
             ServerEvent::StatusChange(ref tc) => {
                 assert_eq!(tc.change_type, StatusChangeType::Up);
-                assert_eq!(format!("{:?}", tc.addr.addr), "V4(127.0.0.1:1)");
+                assert_eq!(tc.addr.addr, "127.0.0.1:1".parse().unwrap());
             }
             _ => panic!("should be status change up"),
         }
@@ -635,7 +635,7 @@ mod server_event {
         match event {
             ServerEvent::StatusChange(ref tc) => {
                 assert_eq!(tc.change_type, StatusChangeType::Down);
-                assert_eq!(format!("{:?}", tc.addr.addr), "V4(127.0.0.1:1)");
+                assert_eq!(tc.addr.addr, "127.0.0.1:1".parse().unwrap());
             }
             _ => panic!("should be status change down"),
         }

--- a/src/frame/frame_event.rs
+++ b/src/frame/frame_event.rs
@@ -72,7 +72,7 @@ mod tests {
         match event {
             ServerEvent::TopologyChange(ref tc) => {
                 assert_eq!(tc.change_type, TopologyChangeType::NewNode);
-                assert_eq!(format!("{:?}", tc.addr.addr), "V4(127.0.0.1:1)");
+                assert_eq!(tc.addr.addr, "127.0.0.1:1".parse().unwrap());
             }
             _ => panic!("should be topology change event"),
         }

--- a/src/frame/parser.rs
+++ b/src/frame/parser.rs
@@ -45,7 +45,7 @@ where
     let full_body = if flags.iter().any(|flag| flag == &Flag::Compression) {
         compressor
             .decode(body_bytes)
-            .map_err(|err| error::Error::from(err.description()))?
+            .map_err(|err| error::Error::from(err.to_string()))?
     } else {
         body_bytes
     };

--- a/src/frame/parser_async.rs
+++ b/src/frame/parser_async.rs
@@ -53,7 +53,7 @@ where
   let full_body = if flags.iter().any(|flag| flag == &Flag::Compression) {
     compressor
       .decode(body_bytes)
-      .map_err(|err| error::Error::from(err.description()))?
+      .map_err(|err| error::Error::from(err.to_string()))?
   } else {
     body_bytes
   };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -26,17 +26,6 @@ macro_rules! query_values {
 }
 
 #[macro_export]
-macro_rules! builder_opt_field {
-    ($field:ident, $field_type:ty) => {
-        pub fn $field(mut self,
-                          $field: $field_type) -> Self {
-            self.$field = Some($field);
-            self
-        }
-    };
-}
-
-#[macro_export]
 macro_rules! list_as_rust {
     ($($into_type:tt)+) => (
         impl AsRustType<Vec<$($into_type)+>> for List {

--- a/src/query/query_params_builder.rs
+++ b/src/query/query_params_builder.rs
@@ -29,7 +29,11 @@ impl QueryParamsBuilder {
   }
 
   /// Sets new flags.
-  builder_opt_field!(flags, Vec<QueryFlags>);
+  pub fn flags(mut self, flags: Vec<QueryFlags>) -> Self {
+    self.flags = Some(flags);
+
+    self
+  }
 
   /// Sets new values.
   /// Sets new query consistency
@@ -49,7 +53,11 @@ impl QueryParamsBuilder {
   }
 
   /// Sets new with_names parameter value.
-  builder_opt_field!(with_names, bool);
+  pub fn with_names(mut self, with_names: bool) -> Self {
+    self.with_names = Some(with_names);
+
+    self
+  }
 
   /// Sets new values.
   /// Sets new query consistency
@@ -76,10 +84,18 @@ impl QueryParamsBuilder {
   }
 
   /// Sets new serial_consistency value.
-  builder_opt_field!(serial_consistency, Consistency);
+  pub fn serial_consistency(mut self, serial_consistency: Consistency) -> Self {
+    self.serial_consistency = Some(serial_consistency);
+
+    self
+  }
 
   /// Sets new timestamp value.
-  builder_opt_field!(timestamp, i64);
+  pub fn timestamp(mut self, timestamp: i64) -> Self {
+    self.timestamp = Some(timestamp);
+
+    self
+  }
 
   /// Finalizes query building process and returns query itself
   pub fn finalize(self) -> QueryParams {


### PR DESCRIPTION
# Failing tests
The failing tests occured because it relied on the output of a Debug which is not stable.
To fix the issue now and prevent further issues I created a second SocketAddr to compare with the first one.

# Warnings
* description is deprecated so I replaced with to_string as per the warning.
* Putting a comment above a macro generated function does not apply the comment to the function. There is a way to achieve this with macros[^1]. But I opted to just created the functions manually without the macro because the macro was just making things more obtuse. Let me know if you really want the macro and ill pass the comment through the macro instead.

Theres still 2 warnings left, but they looked a bit more involved to fix so I didnt touch them.

[^1]: https://stackoverflow.com/questions/41361897/documenting-a-function-created-with-a-macro-in-rust