### PR TITLE
Add github actions CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Testing
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - name: Release
+            cargo_profile: --release
+          - name: Debug
+            cargo_profile:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install latest stable
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: stable
+    - name: Build
+      run: cargo build ${{ matrix.cargo_profile }} --all-targets
+    - name: Run tests
+      run: cargo test ${{ matrix.cargo_profile }} -- --include-ignored


### PR DESCRIPTION
Sorry to suddenly jump in and declare your project needs CI!
But I think it would be very useful to detect test failures like https://github.com/AlexPikalov/cassandra-proto/pull/7 earlier.

It tests with and without --release concurrently on separate VMs

I explicitly used `cargo build ${{ matrix.cargo_profile }} --all-targets` to ensure examples continue to build if they are ever added in the future.