### PR TITLE
Derive Clone and PartialEq for Frame

### DIFF
--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -34,7 +34,7 @@ use crate::error;
 
 pub use self::traits::*;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Frame {
     pub version: Version,
     pub flags: Vec<Flag>,
@@ -80,7 +80,7 @@ impl<'a> IntoBytes for Frame {
 }
 
 /// Frame's version
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Version {
     Request,
     Response,
@@ -169,7 +169,7 @@ impl From<Vec<u8>> for Version {
 
 /// Frame's flag
 // Is not implemented functionality. Only Igonore works for now
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Flag {
     Compression,
     Tracing,
@@ -258,7 +258,7 @@ impl From<u8> for Flag {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Opcode {
     Error,
     Startup,


### PR DESCRIPTION
Clone is very useful, it allows:
*  modifying a frame while leaving the original untouched
*  Sending a frame to another thread/task while retaining a local copy.

PartialEq is a little unusual but we happen to need it and it doesnt require any nested PartialEq additions.
Let me know if its problematic and I can investigate ways in which we can avoid needing it.