### PR TITLE
Add query decoding

### DIFF
--- a/src/frame/frame_query.rs
+++ b/src/frame/frame_query.rs
@@ -1,6 +1,7 @@
 #![warn(missing_docs)]
 //! Contains Query Frame related functionality.
 use rand;
+use std::io::Cursor;
 
 use crate::frame::*;
 use crate::consistency::Consistency;
@@ -57,6 +58,18 @@ impl BodyReqQuery {
                                                    paging_state,
                                                    serial_consistency,
                                                    timestamp, }, }
+    }
+}
+
+impl FromCursor for BodyReqQuery {
+    fn from_cursor(cursor: &mut Cursor<&[u8]>) -> error::Result<BodyReqQuery> {
+        let query = CStringLong::from_cursor(cursor)?;
+        let query_params = QueryParams::from_cursor(cursor)?;
+
+        Ok(BodyReqQuery {
+            query,
+            query_params
+        })
     }
 }
 

--- a/src/frame/frame_response.rs
+++ b/src/frame/frame_response.rs
@@ -13,6 +13,8 @@ use crate::frame::frame_authenticate::BodyResAuthenticate;
 use crate::frame::frame_auth_success::BodyReqAuthSuccess;
 use crate::types::rows::Row;
 
+use super::frame_query::BodyReqQuery;
+
 #[derive(Debug)]
 pub enum ResponseBody {
     Error(CDRSError),
@@ -21,7 +23,7 @@ pub enum ResponseBody {
     Authenticate(BodyResAuthenticate),
     Options,
     Supported(BodyResSupported),
-    Query,
+    Query(BodyReqQuery),
     Result(ResResultBody),
     Prepare,
     Execute,
@@ -40,7 +42,7 @@ impl ResponseBody {
             // request frames
             Opcode::Startup => unreachable!(),
             Opcode::Options => unreachable!(),
-            Opcode::Query => unreachable!(),
+            Opcode::Query => ResponseBody::Query(BodyReqQuery::from_cursor(&mut cursor)?),
             Opcode::Prepare => unreachable!(),
             Opcode::Execute => unreachable!(),
             Opcode::Register => unreachable!(),


### PR DESCRIPTION
Query decoding is useful if you are writing a cassandra implementation or a proxy.

Implemented as per `4.1.4. QUERY` in https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec